### PR TITLE
Fixed TOVola's configuration.ccl to reflect its dependency on GSL

### DIFF
--- a/TOVola/configuration.ccl
+++ b/TOVola/configuration.ccl
@@ -1,3 +1,3 @@
-requires HDF5
+requires HDF5 GSL
 
 #This is all for now


### PR DESCRIPTION
This pull request fixes an issue in TOVola's configuration.ccl file by explicitly adding GSL as a dependency.