### PR TITLE
Removed TOVola_EOS_type parameter, as it is redundant

### DIFF
--- a/TOVola/par/Piecewise.par
+++ b/TOVola/par/Piecewise.par
@@ -29,7 +29,6 @@ TOVola::TOVola_Interpolation_Stencil = 12
 TOVola::TOVola_ODE_method = "ADP8"
 TOVola::TOVola_central_baryon_density = 1.58e-3
 TOVola::TOVola_error_limit = 1.0e-8
-TOVola::TOVola_EOS_type = "Piecewise"
 
 #---------ADMBase (and HydroBase)---------
 HydroBase::initial_hydro         = "TOVola"

--- a/TOVola/par/Simple.par
+++ b/TOVola/par/Simple.par
@@ -29,7 +29,6 @@ TOVola::TOVola_Interpolation_Stencil = 12
 TOVola::TOVola_ODE_method = "ADP8"
 TOVola::TOVola_central_baryon_density = 0.125
 TOVola::TOVola_error_limit = 1.0e-8
-TOVola::TOVola_EOS_type = "Simple"
 
 #---------ADMBase (and HydroBase)---------
 HydroBase::initial_hydro         = "TOVola"

--- a/TOVola/par/Tabulated.par
+++ b/TOVola/par/Tabulated.par
@@ -30,7 +30,6 @@ TOVola::TOVola_Tin = 1.0e-2
 TOVola::TOVola_ODE_method = "ADP8"
 TOVola::TOVola_central_baryon_density = 1.58e-3
 TOVola::TOVola_error_limit = 1.0e-8
-TOVola::TOVola_EOS_type = "Tabulated"
 
 #---------HydroBase---------
 HydroBase::initial_hydro       = "TOVola"

--- a/TOVola/param.ccl
+++ b/TOVola/param.ccl
@@ -53,13 +53,6 @@ CCTK_REAL TOVola_central_baryon_density "What's the initial baryon density? (Use
 {
 	(0.0:* :: "Must be Positive"
 } 0.125
-
-KEYWORD TOVola_EOS_type "What EOS type are you using?"
-{
-	"Simple" :: "Simple Polytrope"
-	"Piecewise" :: "Piecewise Polytrope"
-	"Tabulated" :: "Tabulated EOS"
-} "Simple"
 #################################################################################################################
 
 

--- a/TOVola/src/TOVola_driver.c
+++ b/TOVola/src/TOVola_driver.c
@@ -73,12 +73,11 @@ void TOVola_Parameter_Checker(CCTK_ARGUMENTS) {
   CCTK_INFO("TOVola Validating Interpolation stencil and EOS_type...");
 
   if (TOVola_Interpolation_Stencil > TOVola_Max_Interpolation_Stencil) {
-    CCTK_PARAMWARN("TOVola_Interpolation_Stencil must not exceed the "
-                   "Max_Interpolation_Stencil");
+    CCTK_ERROR("TOVola_Interpolation_Stencil must not exceed the "
+               "Max_Interpolation_Stencil");
   }
-  if (CCTK_EQUALS("Simple", TOVola_EOS_type) && ghl_eos->neos != 1) {
-    CCTK_PARAMWARN("Error: Too many regions for the simple polytrope. Check "
-                   "your value for neos, or use a piecewise polytrope.");
+  if (ghl_eos->eos_type == ghl_eos_simple) {
+    CCTK_ERROR("Error: TOVola does not support GRHayL's Simple EOS.");
   }
   CCTK_INFO("Validation Complete!");
 }
@@ -102,13 +101,12 @@ void TOVola_Solve_and_Interp(CCTK_ARGUMENTS) {
   gsl_odeiv2_driver *driver;
 
   // Setting EOS
-  if (CCTK_EQUALS("Simple", TOVola_EOS_type)) {
-    TOVdata->eos_type = 0;
-  } else if (CCTK_EQUALS("Piecewise", TOVola_EOS_type)) {
-    TOVdata->eos_type = 1;
-  } else if (CCTK_EQUALS("Tabulated", TOVola_EOS_type)) {
+  if (ghl_eos->eos_type == ghl_eos_tabulated) {
     TOVdata->eos_type = 2;
     ghl_tabulated_compute_Ye_P_eps_of_rho_beq_constant_T(TOVola_Tin, ghl_eos);
+  } else {
+    // 0 if neos = 1, else 1.
+    TOVdata->eos_type = (ghl_eos->neos != 1);
   }
 
   // Initialize other TOVdata member variables

--- a/TOVola/src/TOVola_driver.c
+++ b/TOVola/src/TOVola_driver.c
@@ -73,11 +73,11 @@ void TOVola_Parameter_Checker(CCTK_ARGUMENTS) {
   CCTK_INFO("TOVola Validating Interpolation stencil and EOS_type...");
 
   if (TOVola_Interpolation_Stencil > TOVola_Max_Interpolation_Stencil) {
-    CCTK_ERROR("TOVola_Interpolation_Stencil must not exceed the "
-               "Max_Interpolation_Stencil");
+    CCTK_ParamWarn("TOVola_Interpolation_Stencil must not exceed the "
+                   "Max_Interpolation_Stencil");
   }
   if (ghl_eos->eos_type == ghl_eos_simple) {
-    CCTK_ERROR("Error: TOVola does not support GRHayL's Simple EOS.");
+    CCTK_ParamWarn("TOVola does not support GRHayL's Simple EOS.");
   }
   CCTK_INFO("Validation Complete!");
 }


### PR DESCRIPTION
This pull request removes the `TOVola_EOS_type` parameter, which is both redundant (`GRHayLib` provides the equation of state type) and confusing (`"Simple"` means different things in `TOVola` and `GRHayLib`).

Test results should be oblivious to this change, but test parameter files were updated to remove the now non-existent parameter.