### PR TITLE
Removed MIN/MAX Macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 Cactus Code Thorn TOVola
+
 Author(s)     : David Boyer
-Note          : This code uses GSL as the heart ODE solver 
-		and uses GRHayLib thorn to store EOS data.
+
+Note          : This code uses GSL as the heart ODE solver and uses GRHayLib thorn to store EOS data.
+
 Maintainer(s) : David Boyer
+
 License       : BSD-2
+
 --------------------------------------------------------------------------
 
-==========
+============
+
 1. Purpose
-==========
+
+============
 
 TOVola is an Einstein Toolkit thorn that solves the TOV equations, or the equations 
 of hydrostatic equilibrium for spherically symmetric static stars, specifically 
 Neutron stars. It was designed for straightforward use and allow for multiple
 types of EOS.
 
-==========
+============
+
 2. Support
-==========
+
+============
 
 TOVola supports three types of EOS: Simple Polytrope, Piecewise Polytrope, 
 and Tabulated EOS.
@@ -30,9 +38,11 @@ All these choices can be made in the parfile. No touching the src code is
 necessary (as it should be). For examples of using each EOS type, see the par directory,
 or the "Compatible Equations of State" section in the documentation.
 
-==========
+============
+
 3. Testing
-==========
+   
+============
 
 This code has been tested against both the NRpy generated TOV solver and 
 constraint tested using Baikal.
@@ -49,9 +59,11 @@ Tabulated EOS:
 Raw data sits within 10^-8 in relative error with NRpy (Mostly from EOS table interpolation)
 Constraint violation tested with Baikal
 
-===================
+=====================
+
 4. Acknowledgements
-===================
+   
+=====================
 
 I acknowledge the use of LLMs for final code cleanup and organization. The code itself was still human-written.
 

--- a/TOVola/src/TOVola_interp.h
+++ b/TOVola/src/TOVola_interp.h
@@ -79,12 +79,12 @@ static void TOVola_TOV_interpolate_1D(
         TOVola_bisection_idx_finder(rr_iso, numpoints_arr, r_iso_arr);
 
     /* Use standard library functions instead of redefining macros */
-    CCTK_INT idxmin = MAX(0, idx_mid - Interpolation_Stencil / 2 - 1);
+    CCTK_INT idxmin = ghl_imax(0, idx_mid - Interpolation_Stencil / 2 - 1);
 
     // -= Do not allow the interpolation stencil to cross the star's surface =-
     // max index is when idxmin + (TOVola_Interpolation_stencil-1) = R_idx
     //  -> idxmin at most can be R_idx - TOVola_Interpolation_stencil + 1
-    idxmin = MIN(idxmin, R_idx - Interpolation_Stencil + 1);
+    idxmin = ghl_imin(idxmin, R_idx - Interpolation_Stencil + 1);
 
     // Ensure that Interpolation_Stencil does not exceed the maximum
     if (Interpolation_Stencil > Max_Interpolation_Stencil) {


### PR DESCRIPTION
This PR removes old `MIN`/`MAX` macros provided by `GRHayL`, replacing them with `ghl_imin`/`ghl_imax`, provided by `GRHayLib.h`